### PR TITLE
Drop edition requirement down to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitflags/bitflags-derive"
 description = "bitflags-aware #[derive] macros."
 keywords = ["bit", "bitmask", "bitflags", "flags"]
 categories = ["no-std"]
-edition = "2024"
+edition = "2021"
 exclude = ["/tests", "/.github"]
 
 [dependencies.bitflags-derive-macros]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitflags/bitflags-derive"
 description = "bitflags-aware #[derive] macros."
 keywords = ["bit", "bitmask", "bitflags", "flags"]
 categories = ["no-std"]
-edition = "2024"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/tests/ui/Cargo.toml
+++ b/tests/ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags-derive-tests-ui"
 version = "0.0.0"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dependencies.bitflags-derive]


### PR DESCRIPTION
The 2024 edition isn't stable yet, and we don't use anything from it so dropping this back to 2021.